### PR TITLE
Feature/GitHub actions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn
+      
+      - name: run tests
+        run: yarn test form

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Version Bump
         uses: rimonhanna/gh-action-bump-version@master
         env:
-          PACKAGEJSON_DIR: ./dist/libs/form
+          PACKAGEJSON_DIR: dist/libs/form
       - name: Publish to npm
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build npm package
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
     steps:
       - uses: actions/checkout@v1
       - name: Automated Github Action Version Bump

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
     branches: 
     - master 
 
-name: Bump version, build and release npm package
+name: build and release npm package
 jobs:
   build-npm:
     name: Build npm package
@@ -11,12 +11,18 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
     steps:
-      - uses: actions/checkout@v1
-      - name: Automated Github Action Version Bump
+      - name: Checkout repo
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Test and build
+        run: yarn cd-form-documentation
+      - name: Version Bump
         uses: rimonhanna/gh-action-bump-version@master
-      - run: npm i
-      - run: npm test
+        env:
+          PACKAGEJSON_DIR: ./dist/libs/form
       - name: Publish to npm
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          package: ./dist/libs/form/package.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,5 @@ jobs:
           git_email: bcomnes@gmail.com
           git_username: ${{ github.actor }}
           newversion: ${{ steps.bump.outputs.version }}
-          push_version_commit: true 
           github_token: ${{ secrets.GITHUB_TOKEN }} 
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,19 +11,12 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - id: bump
-        name: Bump product version
-        uses: rymndhng/release-on-push-action@master
-        with:
-          bump_version_scheme: minor # gets overriden by PR label
       - uses: actions/checkout@v1
+      - name: Automated Github Action Version Bump
+        uses: rimonhanna/gh-action-bump-version@master
       - run: npm i
       - run: npm test
-      - name: Version and publush to npm
-        uses: bcomnes/npm-bump@v1.0.4
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v1
         with:
-          git_email: bcomnes@gmail.com
-          git_username: ${{ github.actor }}
-          newversion: ${{ steps.bump.outputs.version }}
-          github_token: ${{ secrets.GITHUB_TOKEN }} 
-          npm_token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: 
     - master 
+
 name: Bump version, build and release npm package
 jobs:
   build-npm:
@@ -11,11 +12,19 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - id: bump
+        name: Bump product version
         uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: minor # gets overriden by PR label
       - uses: actions/checkout@v1
       - run: npm i
       - run: npm test
-      - run: npm version ${{ steps.bump.outputs.version }}
-      - run: npm publish
+      - name: Version and publush to npm
+      - uses: bcomnes/npm-bump@v1.0.4
+        with:
+          git_email: bcomnes@gmail.com
+          git_username: ${{ github.actor }}
+          newversion: ${{ steps.bump.outputs.version }}
+          push_version_commit: true 
+          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm i
       - run: npm test
       - name: Version and publush to npm
-      - uses: bcomnes/npm-bump@v1.0.4
+        uses: bcomnes/npm-bump@v1.0.4
         with:
           git_email: bcomnes@gmail.com
           git_username: ${{ github.actor }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/checkout@v1
       - name: Install dependencies
         run: yarn
-      - name: Test and build
-        run: yarn cd-form-documentation
+      - name: Test
+        run: yarn test form
+      - name: Build
+        run: yarn build form
       - name: Version Bump
         uses: rimonhanna/gh-action-bump-version@master
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,18 +13,26 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1
+        
       - name: Install dependencies
         run: yarn
+        
       - name: Test
         run: yarn test form
+        
       - name: Build
         run: yarn build form
-      - name: Version Bump
-        uses: rimonhanna/gh-action-bump-version@master
-        env:
-          PACKAGEJSON_DIR: dist/libs/form
-      - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v1
+        
+      - name: Bump, tag and release
+        id: bump
+        uses: rymndhng/release-on-push-action@master
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./dist/libs/form/package.json
+          bump_version_scheme: norelease
+        
+      - name: Version Bump
+        run: cd dist/libs/form && yarn version --new-version "${steps.bump.outputs.version}" --no-git-tag-version
+
+      - name: Publish
+        run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: 
-    - feature/github-actions
+    - master
 
 name: build and release npm package
 jobs:
@@ -27,10 +27,13 @@ jobs:
         id: bump
         uses: rymndhng/release-on-push-action@master
         with:
-          bump_version_scheme: norelease
+          bump_version_scheme: norelease # gets overriden by PR labels
         
       - name: Version Bump
-        run: cd dist/libs/form && yarn version --new-version "${steps.bump.outputs.version}" --no-git-tag-version
+        run: |
+          echo ${{steps.bump.outputs.version}}
+          cd dist/libs/form 
+          yarn version --new-version "${{ steps.bump.outputs.version }}" --no-git-tag-version
 
       - name: Publish
         run: yarn publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: 
-    - master 
+    - feature/github-actions
 
 name: build and release npm package
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches: 
+    - master 
+name: Bump version, build and release npm package
+jobs:
+  build-npm:
+    name: Build npm package
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: bump
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: minor # gets overriden by PR label
+      - uses: actions/checkout@v1
+      - run: npm i
+      - run: npm test
+      - run: npm version ${{ steps.bump.outputs.version }}
+      - run: npm publish


### PR DESCRIPTION
Adds 2 workflows:
1. CI on PR: run the tests and ensure everything is OK before enabling merge button
2. NPM release on PR merge to `master`: if the PR contains a `release:major` / `release:minor` / `release:patch` labels, the appropriate version will be bumped, creating a GH release and a git tag. Also the build will be published to npm with the new version. If the PR doesn't contain a label, then no bumping will occur, neither will a release will be created (**NOTE**: `yarn publish` might fail because it will try to publish the same version) 